### PR TITLE
Add FuturX Token (FTRX)

### DIFF
--- a/src/tokens/8RRGMNCb2bPiTkveGpkkxDtEQh3mar8gH5e3hrtSiYjS.json
+++ b/src/tokens/8RRGMNCb2bPiTkveGpkkxDtEQh3mar8gH5e3hrtSiYjS.json
@@ -1,0 +1,14 @@
+{
+  "chainId": 101,
+  "address": "8RRGMNCb2bPiTkveGpkkxDtEQh3mar8gH5e3hrtSiYjS",
+  "symbol": "FTRX",
+  "name": "FuturX",
+  "decimals": 9,
+  "logoURI": "https://gateway.pinata.cloud/ipfs/bafkreifwlkgvc3hhnxvvt5zng4mijfzrg7kd2lcbzrap6j7q3hefg2id3q",
+  "tags": ["utility-token", "social-project"],
+  "extensions": {
+    "website": "https://futurx.notion.site",
+    "twitter": "https://twitter.com/Futurx2025",
+    "description": "FuturX is the first social crypto token funding a permanent Santa Claus Village for children with disabilities."
+  }
+}


### PR DESCRIPTION
This pull request adds the FuturX token (FTRX) to the Solana Token Registry.

FuturX is a social crypto token designed to fund the creation of a permanent Santa Claus Village for children with disabilities. All metadata is hosted on IPFS and the token is fully on-chain and verified.

*Token Details:*
- Name: FuturX
- Symbol: FTRX
- Mint: 8RRGMNCb2bPiTkveGpkkxDtEQh3mar8gH5e3hrtSiYjS
- Decimals: 9
- Logo: IPFS hosted

Thank you for reviewing and supporting this project!
