### PR TITLE
Add FuturX Token (FTRX) to the Solana Token Registry

### DIFF
--- a/src/tokens/FTRX.json
+++ b/src/tokens/FTRX.json
@@ -1,0 +1,14 @@
+{
+  "chainId": 101,
+  "address": "BRRGMNCb2bPiTKveGpkkxDtEQh3mar8gH5e3hrtSiYjS",
+  "symbol": "FTRX",
+  "name": "FuturX",
+  "decimals": 9,
+  "logoURI": "https://gateway.pinata.cloud/ipfs/bafkreiaiykc3hnxxvt52ng4i3jfra92kzbj6zrap6j73hqefg2iidd3r4",
+  "tags": ["social", "project"],
+  "extensions": {
+    "website": "https://www.notion.site/futurx",
+    "twitter": "https://twitter.com/Futurx2025"
+  },
+  "description": "FuturX is the first social crypto token funding a permanent Santa Claus Village for children with disabilities."
+}


### PR DESCRIPTION

This pull request proposes the addition of the FuturX token (FTRX) to the official Solana Token Registry.

FuturX is the first social crypto token designed to fund a permanent Santa Claus Village dedicated to children with disabilities and their families. The project is transparent, verifiable, and driven by a strong humanitarian mission.

*Token details:*
- Name: FuturX
- Symbol: FTRX
- Mint address: BRRGMNCb2bPiTKveGpkkxDtEQh3mar8gH5e3hrtSiYjS
- Decimals: 9
- Logo URI (IPFS): https://gateway.pinata.cloud/ipfs/bafkreiaiykc3hnxxvt52ng4i3jfra92kzbj6zrap6j73hqefg2iidd3r4
- Website: https://www.notion.site/futurx
- Twitter: https://twitter.com/Futurx2025

Thank you for reviewing and supporting this social-impact crypto initiative!